### PR TITLE
fix #issue-5

### DIFF
--- a/src/hooks/skfde
+++ b/src/hooks/skfde
@@ -5,7 +5,6 @@ SKFDE_CONFIG_FILE="/etc/skfde.conf"
 SKFDE_SLEEP_AFTER_SUCCESSFUL_CRYPTSETUP="5"
 SKFDE_CRYPTSETUP_RETRY="3"
 SKFDE_PIN_SOURCE="pin.txt"
-SKFDE_LUKS_KEYSLOT="3"
 
 message() {
   echo "$@" >&2
@@ -41,7 +40,6 @@ skfde_open() {
 
   message "Passing SoloKey response to cryptsetup"
   _tmp="$(printf %s "$_skfde_response" | cryptsetup luksOpen \
-    --key-slot=$SKFDE_LUKS_KEYSLOT \
     $SKFDE_LUKS_DEV $SKFDE_LUKS_NAME 2>&1)"
   _rc=$?
 


### PR DESCRIPTION
Fix: #5 

Removed the key-slot option in skfde hook, so the solokey response can be matched against any of the keyslot.